### PR TITLE
Changes to _pks and README.MD files

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,20 +1,115 @@
-# PKS CLI zsh complete plugin
-This [zsh](http://www.zsh.org/) plugin adds autocompletion options for all PKS CLI Commands
+# [PKS](https://pivotal.io/platform/pivotal-container-service) CLI zsh autocomplete plugin
+
+We use a [zsh](http://www.zsh.org/) plugin to add [zsh autocompletion](https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org) options for all PKS CLI Commands
+
+# How will it work?
+
+When, for example, you type `pks c` and then press `Tab` you will be offered the following choices to autocomplete your command:
+
+```
+cluster                 -- View the details of the cluster
+clusters                -- Show all clusters created with PKS
+create-cluster          -- Creates a kubernetes cluster, requires cluster na
+create-network-profile  -- Create a network profile
+create-sink             -- Creates a sink for sending all log data to syslog
+```
+
+Let's say you picked the `create-cluster` option and that you typed in the name `k8s-cluster`.
+
+You should have `pks create-cluster k8s-cluster`. You then press `Tab` again to see additional choices:
+
+```
+--external-hostname  -- Address from which to access Kubernetes API
+--help               -- help for create-cluster
+--json               -- Return the PKS-API output as json
+--network-profile    -- Optional, network profile name (NSX-T only)
+--non-interactive    -- Dont ask for user input
+--num-nodes          -- Number of worker nodes
+--plan               -- Preconfigured plans. Run pks plans for more details
+--wait               -- Wait for the operation to finish
+```
+
+If you select `--plan` and then press `Tab` again, you will be given a choice of plans created by your Ops Team. For example:
+
+```
+large   medium  small 
+```
+
+You can continue to press `Tab` for additional choices until you are satisfied with the complete command line at which point you will press `return` to execute the command.
+
 
 ## Installation
 
 * Download the latest version of the [PKS CLI](https://network.pivotal.io/products/pivotal-container-service)
 
-### Oh-My-Zsh
+* On a Mac, you'll need you will need to execute the following command to install the [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework. 
+
+```sh -c "$(curl -fsSL https://preview.tinyurl.com/install-oh-my-zsh-MacOS)"```
+
+* For other Operating Systems look for instructions [here](https://github.com/robbyrussell/oh-my-zsh)
+
+### Let's extend the Oh-My-Zsh framework with a custom plugin:
 
 * Clone this repo to your zsh plugins directory:
 
 ```
-$ cd ~/.oh-my-zsh/plugins
-$ git clone https://github.com/tybritten/pks-zsh-autocomplete-plugin.git pks
+$ cd ~/.oh-my-zsh/custom/plugins
+$ git clone https://github.com/rm511130/pks-zsh-autocomplete-plugin.git pks
 ```
 
-* Add the `pks` plugin to your `.zshrc` file:
+* Add the `pks` plugin to your `~/.zshrc` file:
 
 ```
 plugins=(... pks)
+```
+
+In my case, for example, that part of the `~/.zshrc` file looks like this:
+
+```
+# Which plugins would you like to load?
+# Standard plugins can be found in ~/.oh-my-zsh/plugins/*
+# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
+# Example format: plugins=(rails git textmate ruby lighthouse)
+# Add wisely, as too many plugins slow down shell startup.
+
+plugins=(git pks kubectl cloudfoundry)
+
+source $ZSH/oh-my-zsh.sh
+```
+
+As you can see, the `pks` custom plugin has been added to the list.
+
+Additionally, in order to make the autocompletion work, I had to append at the end of the same `~/.zshrc` the following lines:
+
+```
+# enable autocomplete function
+autoload -Uz compinit
+compinit
+```
+
+### Next Steps
+
+* Make sure you start a new terminal window so that the changes described above take effect, and try typing `pks` and then press the `Tab` key. You should see the following list of choices.
+
+```
+cluster                 -- View the details of the cluster
+clusters                -- Show all clusters created with PKS
+create-cluster          -- Creates a kubernetes cluster, requires cluster na
+create-network-profile  -- Create a network profile
+create-sink             -- Creates a sink for sending all log data to syslog
+delete-cluster          -- Deletes a kubernetes cluster, requires cluster na
+delete-network-profile  -- Delete a network profile
+delete-sink             -- Deletes a sink from the given cluster
+get-credentials         -- Allows you to connect to a cluster and use kubect
+get-kubeconfig          -- Allows you to get kubeconfig for your username
+help                    -- Help about any command
+login                   -- Log in to PKS
+logout                  -- Log out of PKS
+network-profile         -- View a network profile
+network-profiles        -- Show all network profiles created with PKS
+plans                   -- View the preconfigured plans available
+resize                  -- Changes the number of worker nodes for a cluster
+sinks                   -- List sinks for the given cluster
+update-cluster          -- Updates the configuration of a specific kubernete
+upgrade-cluster         -- Upgrades the kubernetes clusters
+```

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # [PKS](https://pivotal.io/platform/pivotal-container-service) CLI zsh autocomplete plugin
 
-We use a [zsh](http://www.zsh.org/) plugin to add [zsh autocompletion](https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org) options for all PKS CLI Commands
+We use the [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) custom plugin framework for [zsh](http://www.zsh.org/) [autocompletion](https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org) to enhance the PKS CLI experience with options for all its PKS commands.
 
 # How will it work?
 

--- a/README.MD
+++ b/README.MD
@@ -49,7 +49,7 @@ You can continue to press `Tab` for additional choices until you are satisfied w
 * For other Operating Systems look for the oh-my-zsh framework installation instructions [here](https://github.com/robbyrussell/oh-my-zsh)
 
 
-### Let's extend the Oh-My-Zsh framework with a custom plugin:
+### Let's extend the Oh-My-Zsh framework with a custom PKS plugin:
 
 * Clone this repo to your zsh custom plugins directory:
 

--- a/README.MD
+++ b/README.MD
@@ -80,7 +80,7 @@ source $ZSH/oh-my-zsh.sh
 
 As you can see, the `pks` custom plugin has been added to the list.
 
-Additionally, in order to make the autocompletion work, I had to append at the end of the same `~/.zshrc` file with the following lines:
+Additionally, in order to enable the oh-my-zsh autocompletion, append the following lines at the end of the same `~/.zshrc` file:
 
 ```
 # enable autocomplete function
@@ -90,7 +90,16 @@ compinit
 
 ### Next Steps
 
-* Make sure you start a new terminal window so that the changes described above take effect, and try typing `pks` and then press the `Tab` key. You should see the following list of choices.
+* Make sure you start a new terminal window so that the changes described above take effect.
+
+* Double check that you are using `zsh`
+
+```
+echo $SHELL
+/bin/zsh
+```
+
+* Try typing `pks` and then press the `Tab` key. You should see the following list of choices:
 
 ```
 cluster                 -- View the details of the cluster

--- a/README.MD
+++ b/README.MD
@@ -80,7 +80,7 @@ source $ZSH/oh-my-zsh.sh
 
 As you can see, the `pks` custom plugin has been added to the list.
 
-Additionally, in order to make the autocompletion work, I had to append at the end of the same `~/.zshrc` the following lines:
+Additionally, in order to make the autocompletion work, I had to append at the end of the same `~/.zshrc` file with the following lines:
 
 ```
 # enable autocomplete function

--- a/README.MD
+++ b/README.MD
@@ -42,7 +42,7 @@ You can continue to press `Tab` for additional choices until you are satisfied w
 
 * Download the latest version of the [PKS CLI](https://network.pivotal.io/products/pivotal-container-service)
 
-* On a Mac, you'll need you will need to execute the following command to install the [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework. 
+* On a Mac, you'll need you will need to execute the following command to install the [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework: 
 
 ```sh -c "$(curl -fsSL https://tinyurl.com/install-oh-my-zsh-MacOS)"```
 

--- a/README.MD
+++ b/README.MD
@@ -80,7 +80,7 @@ source $ZSH/oh-my-zsh.sh
 
 As you can see, the `pks` custom plugin has been added to the list.
 
-Additionally, in order to enable the oh-my-zsh autocompletion, append the following lines at the end of the same `~/.zshrc` file:
+* Additionally, in order to enable the oh-my-zsh autocompletion, append the following lines at the end of the same `~/.zshrc` file:
 
 ```
 # enable autocomplete function

--- a/README.MD
+++ b/README.MD
@@ -51,7 +51,7 @@ You can continue to press `Tab` for additional choices until you are satisfied w
 
 ### Let's extend the Oh-My-Zsh framework with a custom plugin:
 
-* Clone this repo to your zsh plugins directory:
+* Clone this repo to your zsh custom plugins directory:
 
 ```
 cd ~/.oh-my-zsh/custom/plugins
@@ -64,7 +64,7 @@ git clone https://github.com/rm511130/pks-zsh-autocomplete-plugin.git pks
 plugins=(... pks ...)
 ```
 
-In my case, for example, that part of the `~/.zshrc` file looks like this:
+In my case, as an example, that part of the `~/.zshrc` file looks like this:
 
 ```
 # Which plugins would you like to load?

--- a/README.MD
+++ b/README.MD
@@ -44,23 +44,24 @@ You can continue to press `Tab` for additional choices until you are satisfied w
 
 * On a Mac, you'll need you will need to execute the following command to install the [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework. 
 
-```sh -c "$(curl -fsSL https://preview.tinyurl.com/install-oh-my-zsh-MacOS)"```
+```sh -c "$(curl -fsSL https://tinyurl.com/install-oh-my-zsh-MacOS)"```
 
-* For other Operating Systems look for instructions [here](https://github.com/robbyrussell/oh-my-zsh)
+* For other Operating Systems look for the oh-my-zsh framework installation instructions [here](https://github.com/robbyrussell/oh-my-zsh)
+
 
 ### Let's extend the Oh-My-Zsh framework with a custom plugin:
 
 * Clone this repo to your zsh plugins directory:
 
 ```
-$ cd ~/.oh-my-zsh/custom/plugins
-$ git clone https://github.com/rm511130/pks-zsh-autocomplete-plugin.git pks
+cd ~/.oh-my-zsh/custom/plugins
+git clone https://github.com/rm511130/pks-zsh-autocomplete-plugin.git pks
 ```
 
 * Add the `pks` plugin to your `~/.zshrc` file:
 
 ```
-plugins=(... pks)
+plugins=(... pks ...)
 ```
 
 In my case, for example, that part of the `~/.zshrc` file looks like this:

--- a/_pks
+++ b/_pks
@@ -5,7 +5,12 @@
 # Output a selectable list of clusters
 __pks_clusters() {
     declare -a cont_cmd
-    cont_cmd=($(pks clusters | awk -F '  ' 'NR>2{print $1}'))
+    if [[ $(pks --version | awk -F '.' '{print $2}') -lt 5 ]]
+    then
+      cont_cmd=($(pks clusters | awk -F '  ' 'NR>2{print $1}'))
+    else
+      cont_cmd=($(pks clusters | awk 'NR>2{print $1}'))
+    fi
     if [[ 'X$cont_cmd' != 'X' ]]
         _describe 'CLUSTER' cont_cmd
 }
@@ -14,7 +19,7 @@ __pks_clusters() {
 # TODO add to plan options during create-cluster
 __pks_plans() {
     declare -a cont_cmd
-    cont_cmd=($(pks plans | awk -F '  ' 'NR>2{print $1}'))
+    cont_cmd=($(pks plans --json | grep "\"name\":" | awk '{ gsub("\"","",$2); gsub(",","",$2); print $2; }'))
     if [[ 'X$cont_cmd' != 'X' ]]
         _describe 'PLANS' cont_cmd
 }
@@ -39,6 +44,7 @@ _pks_cmds=(
   'delete-network-profile:Delete a network profile'
   'delete-sink:Deletes a sink from the given cluster'
   'get-credentials:Allows you to connect to a cluster and use kubectl'
+  'get-kubeconfig:Allows you to get kubeconfig for your username'
   'help:Help about any command'
   'login:Log in to PKS'
   'logout:Log out of PKS'
@@ -47,6 +53,8 @@ _pks_cmds=(
   'plans:View the preconfigured plans available'
   'resize:Changes the number of worker nodes for a cluster'
   'sinks:List sinks for the given cluster'
+  'update-cluster:Updates the configuration of a specific kubernetes cluster'
+  'upgrade-cluster:Upgrades the kubernetes clusters'
 )
 
 __cluster() {
@@ -71,7 +79,7 @@ __create-cluster() {
         '--network-profile[Optional, network profile name (NSX-T only)]' \
         '--non-interactive[Dont ask for user input]' \
         '--num-nodes[Number of worker nodes]' \
-        '--plan[Preconfigured plans. Run pks plans for more details]' \
+        '--plan[Preconfigured plans. Run pks plans for more details]:plans existing_plans:__pks_plans' \
         '--wait[Wait for the operation to finish]' 
 }
 
@@ -116,7 +124,19 @@ __get-credentials() {
       '1:cluster name:__pks_clusters' \
       '--help[help for cluster]' \
 }
-
+__get-kubeconfig() {
+    _arguments \
+      '1:cluster name:__pks_clusters' \
+      '--api[The PKS API server URI]' \
+      '--ca-cert[Path to CA Cert for PKS API]' \
+      '--help[help for login]' \
+      '--password[Password]' \
+      '--skip-ssl-validation[Skip SSL Validation]' \
+      '--sso[Prompt for a one-time passcode to do Single sign-on]' \
+      '--sso-auto[Auto launch local browser to do Single sign-on]' \
+      '--sso-passcode string[Single sign-on with one-time passcode]' \
+      '--username[Username]' \
+}
 __login() {
     _arguments \
       '--api[The PKS API server URI]' \
@@ -165,6 +185,31 @@ __sinks() {
         '--json[Return the PKS-API output as json]' \
 }
 
+__update-cluster(){
+    _arguments \
+        '1:cluster name:__pks_clusters' \
+        '--network-profile[Action flag, Network profile name]' \
+        '--num-nodes[Action flag, Number of worker nodes]' \
+        '--kubelet-drain-timeout[Action flag, The length of time in minutes for drain to wait before giving up.]' \
+        '--kubelet-drain-grace-period[Action flag, Period of time in seconds given to each pod to terminate gracefully.]' \
+        '--kubelet-drain-force[Action flag, Force drain even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet.]' \
+        '--kubelet-drain-ignore-daemonsets[Action flag, Ignore DaemonSet managed pods during drain.]' \
+        '--kubelet-drain-delete-local-data[Action flag, Drain even if there are pods using emptyDir.]' \
+        '--kubelet-drain-force-node[Action flag, Forcefully terminate pods which fail to drain. Use it with caution.]' \
+        '--non-interactive[Dont ask for user input]' \
+        '--json[Return the PKS-API output as json]' \
+        '--wait[Wait for the operation to finish]' \
+        '--help[help for update-cluster]'
+}
+
+__upgrade-cluster() {
+    _arguments \
+        '1:cluster name:__pks_clusters' \
+        '--help[help for upgrade-cluster]' \
+        '--json[Return the PKS-API output as json. Only applicable when used with --wait flag]' \
+        '--non-interactive[Dont ask for user input]'
+}
+
 _arguments '*:: :->command'
 
 if (( CURRENT == 1 )); then
@@ -192,6 +237,8 @@ case "$words[1]" in
     __delete-sink ;;
   get-credentials)
     __get-credentials ;;
+  get-kubeconfig)
+    __get-kubeconfig ;;
   login)
     __login ;;
   network-profile)
@@ -204,4 +251,8 @@ case "$words[1]" in
     __resize ;;
   sinks)
     __sinks ;;
+  update-cluster)
+    __update-cluster ;;
+  upgrade-cluster)
+    __upgrade-cluster ;;
 esac


### PR DESCRIPTION
Tyler, I took the code you sent me via e-mail and made additional changes:

1. Adjustments to the `awk` logic of `__pks_clusters()` and `__pks_plans()` because they weren't returning values.
2. I figured out how to make the `__pks_plans` function work when using the `create-cluster --plan` option.
3. I added lots of text to the README.MD file to address the areas where I got stuck, but the main changes were:
    - the use of `~/.oh-my-zsh/custom/plugins/pks` instead of `~/.oh-my-zsh/plugins/pks` 
    - the addition of commands in the `~/.zshrc` file to enable autocompletion
4. Last but not least, my instructions point to `https://github.com/rm511130/pks-zsh-autocomplete-plugin.git` so please make sure you revert that back to point to your repo.

I hope this all helps. Thank you for creating the plugin!
